### PR TITLE
[Bug fix]fix limit trunction bug

### DIFF
--- a/functions/user/[[userQuery]].js
+++ b/functions/user/[[userQuery]].js
@@ -21,7 +21,7 @@ export async function onRequestGet(context) {
     if (!userQuery) return errorResponse(400, 'Missing user query');
 
     const { searchParams } = new URL(context.request.url);
-    const limit = Number(searchParams.get('limit') ?? -1);
+    const limit = Number(searchParams.get('limit') ?? 0);
     const year = Number(searchParams.get('year') ?? -1);
 
     const userData = await getUserData(userQuery, year, limit);
@@ -134,7 +134,7 @@ async function getUserData(requestedUser, year, limit) {
     let weekIndex;
     Object.values(data)
         .sort((a, b) => (a.date < b.date ? -1 : 1))
-        .slice(0, limit * 7)
+        .slice(...(limit ? [0, limit * 7] : []))
         .forEach((day, idx) => {
             weekIndex = Math.floor(idx / 7);
             if (!contributions[weekIndex]) contributions.push([]);


### PR DESCRIPTION
The limit bug was reported here: #6 
This pull request contains two parts:
**[bug fix]** Fix slice logic to limit the week's length. 
**[feat]** Changing the direction of truncation from head to tail.
The origin limit logic is to cut off the data from the tail which will reserve the front data of the contribution count list.
It seems a little weird and the data fetched from GitHub API don't show the whole contribution data. As a result, the limited list will just return a list containing the data in the middle. So maybe a limit from the tail is a better choice?